### PR TITLE
Remove support for nonstandard postgresql types

### DIFF
--- a/src/MHasql/TH/Construction/Exp.hs
+++ b/src/MHasql/TH/Construction/Exp.hs
@@ -147,15 +147,15 @@ foldResultDecoder :: Exp -> Exp -> Exp -> Exp -> Exp
 foldResultDecoder step init extract rowDecoder' =
   appList (VarE 'fmap) [extract, appList (VarE 'Decoders.foldlRows) [step, init, rowDecoder']]
 
-unidimensionalParamEncoder :: Bool -> Exp -> Exp
-unidimensionalParamEncoder nullable =
-  applyParamToEncoder . applyNullabilityToEncoder nullable
+unidimensionalParamEncoder :: Exp -> Exp
+unidimensionalParamEncoder =
+  applyParamToEncoder . applyNullabilityToEncoder True
 
-multidimensionalParamEncoder :: Bool -> Int -> Bool -> Exp -> Exp
-multidimensionalParamEncoder nullable dimensionality arrayNull =
-  applyParamToEncoder . applyNullabilityToEncoder arrayNull . AppE (VarE 'Encoders.array)
+multidimensionalParamEncoder :: Int -> Exp -> Exp
+multidimensionalParamEncoder dimensionality =
+  applyParamToEncoder . applyNullabilityToEncoder True . AppE (VarE 'Encoders.array)
     . applyArrayDimensionalityToEncoder dimensionality
-    . applyNullabilityToEncoder nullable
+    . applyNullabilityToEncoder True
 
 applyParamToEncoder :: Exp -> Exp
 applyParamToEncoder = AppE (VarE 'Encoders.param)
@@ -172,15 +172,15 @@ applyArrayDimensionalityToEncoder levels =
 rowDecoder :: [Exp] -> Exp
 rowDecoder = cozip
 
-unidimensionalColumnDecoder :: Bool -> Exp -> Exp
-unidimensionalColumnDecoder nullable =
-  applyColumnToDecoder . applyNullabilityToDecoder nullable
+unidimensionalColumnDecoder :: Exp -> Exp
+unidimensionalColumnDecoder =
+  applyColumnToDecoder . applyNullabilityToDecoder True
 
-multidimensionalColumnDecoder :: Bool -> Int -> Bool -> Exp -> Exp
-multidimensionalColumnDecoder nullable dimensionality arrayNull =
-  applyColumnToDecoder . applyNullabilityToDecoder arrayNull . AppE (VarE 'Decoders.array)
+multidimensionalColumnDecoder :: Int -> Exp -> Exp
+multidimensionalColumnDecoder dimensionality =
+  applyColumnToDecoder . applyNullabilityToDecoder True . AppE (VarE 'Decoders.array)
     . applyArrayDimensionalityToDecoder dimensionality
-    . applyNullabilityToDecoder nullable
+    . applyNullabilityToDecoder True
 
 applyColumnToDecoder :: Exp -> Exp
 applyColumnToDecoder = AppE (VarE 'Decoders.column)

--- a/src/MHasql/TH/Extraction/ChildExprList.hs
+++ b/src/MHasql/TH/Extraction/ChildExprList.hs
@@ -571,7 +571,7 @@ indirectionEl = \case
 
 typeList = foldMap typename
 
-typename (Typename _a b _c _d) =
+typename (Typename _a b _c) =
   simpleTypename b
 
 simpleTypename = \case

--- a/src/MHasql/TH/Extraction/InputTypeList.hs
+++ b/src/MHasql/TH/Extraction/InputTypeList.hs
@@ -13,25 +13,22 @@ import PostgresqlSyntax.Ast
 -- >>> test = either fail (return . preparableStmt) . P.run P.preparableStmt
 --
 -- >>> test "select $1 :: INT"
--- Right [Typename False (NumericSimpleTypename IntNumeric) False Nothing]
+-- Right [Typename False (NumericSimpleTypename IntNumeric) Nothing]
 --
 -- >>> test "select $1 :: INT, a + $2 :: INTEGER"
--- Right [Typename False (NumericSimpleTypename IntNumeric) False Nothing,Typename False (NumericSimpleTypename IntegerNumeric) False Nothing]
+-- Right [Typename False (NumericSimpleTypename IntNumeric) Nothing,Typename False (NumericSimpleTypename IntegerNumeric) Nothing]
 --
 -- >>> test "select $1 :: INT4"
--- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) False Nothing]
+-- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) Nothing]
 --
--- >>> test "select $1 :: text[]?"
--- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "text") Nothing Nothing)) False (Just (BoundsTypenameArrayDimensions (Nothing :| []),True))]
---
--- >>> test "select $1 :: text?[]?"
--- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "text") Nothing Nothing)) True (Just (BoundsTypenameArrayDimensions (Nothing :| []),True))]
+-- >>> test "select $1 :: text[]"
+-- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "text") Nothing Nothing)) (Just (BoundsTypenameArrayDimensions (Nothing :| [])))]
 --
 -- >>> test "select $1"
 -- Left "Placeholder $1 misses an explicit typecast"
 --
 -- >>> test "select $2 :: int4, $1 :: int4, $2 :: int4"
--- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) False Nothing,Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) False Nothing]
+-- Right [Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) Nothing,Typename False (GenericTypeSimpleTypename (GenericType (UnquotedIdent "int4") Nothing Nothing)) Nothing]
 --
 -- >>> test "select $1 :: int4, $1 :: text"
 -- Left "Placeholder $1 has conflicting type annotations"

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -12,3 +12,5 @@ extra-deps:
   - mio-log
   - mprelude
   - source-constraints
+- github: mbj/postgresql-syntax
+  commit: 93352c9105406a96a97ba63dca9374645efee5b6

--- a/stack-9.4.yaml.lock
+++ b/stack-9.4.yaml.lock
@@ -95,6 +95,17 @@ packages:
   original:
     subdir: source-constraints
     url: https://github.com/mbj/mhs/archive/bd1b8bbaf3a69eac0d17bf701945ce817a1bdf31.tar.gz
+- completed:
+    name: postgresql-syntax
+    pantry-tree:
+      sha256: 0b5dec9b00df1e927d73b56c0df02e2d9ad51f29205d81ba0d00b1fc35bc3dbf
+      size: 1841
+    sha256: 799a33b3173f583a5ee68b5c4f3741cf05607a0634e1d62324d87161f942cbb4
+    size: 173513
+    url: https://github.com/mbj/postgresql-syntax/archive/93352c9105406a96a97ba63dca9374645efee5b6.tar.gz
+    version: 0.4.1
+  original:
+    url: https://github.com/mbj/postgresql-syntax/archive/93352c9105406a96a97ba63dca9374645efee5b6.tar.gz
 snapshots:
 - completed:
     sha256: 2cbbf12b252ddfed57ca48fd2e086e534fa91d48e61716e479251729ab7351bf

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -23,5 +23,5 @@ main = do
 testDB :: DBT.ClientConfig -> Tasty.TestTree
 testDB clientConfig =
   Tasty.testCase "smoke test" $
-    Tasty.assertEqual "" True =<< runMIO ()
+    Tasty.assertEqual "" (pure True) =<< runMIO ()
       (DBT.withConnectionSession clientConfig $ Hasql.statement () [MHasql.singletonStatement|SELECT true :: bool|])


### PR DESCRIPTION
* This way of encoding nullable vs non-nullable is the only reason we have to rely on a large part of `postgresql-syntax` namely the renderer.
* I want to experiment with an alternative in followup commits so first removing this feature to not be in the way.